### PR TITLE
Add SYCL backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ pip install -r requirements.txt
 
 # For NPU users:
 pip install torch-npu==2.1.0.post12
+
+# For Intel GPU (torch xpu) users:
+pip install torch==2.7.0 --index-url https://download.pytorch.org/whl/xpu
 ```
 You can rent GPU or NPU resources from online platforms such as [autodl](https://www.autodl.com/home). For TPU resources, you can use services like [Google Colab](https://colab.research.google.com/)
 

--- a/backends/sycl_backend.py
+++ b/backends/sycl_backend.py
@@ -1,0 +1,49 @@
+import torch
+from backends.backend_registry import register_backend, Backend
+import os
+from utils.correctness import execute_template
+from utils.performance import time_execution_event_template
+from config import arch_list_xpu
+
+@register_backend('sycl')
+class SyclBackend(Backend):
+    def __init__(self):
+        self.context = {}
+        self.device = self.get_device()
+
+    def get_device(self):
+        return torch.device('xpu:0')
+
+    def get_hardware_name(self):
+        return torch.xpu.get_device_name(device=self.device)
+
+    def compile(self, generated_code, op):
+        os.environ["TORCH_XPU_ARCH_LIST"] = ";".join(arch_list_xpu)
+        try:
+            compile(generated_code, "<string>", "exec")
+            exec(generated_code, self.context)
+            return True, None
+        except Exception as e:
+            return False, str(e)
+
+    def correctness_execution(self, ref_src):
+        synchronize = torch.xpu.synchronize
+        try:
+            exec(ref_src, self.context)
+        except Exception as e:
+            raise RuntimeError(f"Failed to compile reference model: {str(e)}")
+        return execute_template(synchronize, self.device, self.context)
+
+    def time_execution(self, eval_target='ModelNew'):
+        synchronize = torch.xpu.synchronize
+        event_class = torch.xpu.Event
+        return time_execution_event_template(self.context, self.device, synchronize, event_class, eval_target)
+
+    def cleanup(self):
+        del self.context
+        with torch.xpu.device(self.device):
+            torch.xpu.empty_cache()
+            torch.xpu.reset_peak_memory_stats(device=self.device)
+            torch.xpu.synchronize(
+                device=self.device
+            )

--- a/config.py
+++ b/config.py
@@ -20,6 +20,7 @@ seed_num=1024
 
 # cuda device
 arch_list = ['Ada']
+arch_list_xpu = ['dg2']
 
 # Ascend compile related
 op_engineer_dir = f'{project_root_path}/ascend_op_projects'

--- a/prompt_generators/sycl_add_shot.py
+++ b/prompt_generators/sycl_add_shot.py
@@ -1,0 +1,8 @@
+from prompt_generators.prompt_registry import register_prompt, BasePromptStrategy
+from prompt_generators.prompt_utils import generate_template, read_relavant_files
+
+@register_prompt("sycl", "add_shot")
+class SyclDefaultPromptStrategy(BasePromptStrategy):
+    def generate(self, op) -> str:
+        arc_src, example_arch_src, example_new_arch_src = read_relavant_files('sycl', op, 'add')
+        return generate_template(arc_src, example_arch_src, example_new_arch_src, 'SYCL')

--- a/prompt_generators/sycl_selected_shot.py
+++ b/prompt_generators/sycl_selected_shot.py
@@ -1,0 +1,10 @@
+from prompt_generators.prompt_registry import register_prompt, BasePromptStrategy
+from prompt_generators.prompt_utils import generate_template, read_relavant_files
+from dataset import category2exampleop, dataset
+
+@register_prompt("sycl", "selected_shot")
+class SyclSelectPromptStrategy(BasePromptStrategy):
+    def generate(self, op) -> str:
+        category = dataset[op]['category']
+        arc_src, example_arch_src, example_new_arch_src = read_relavant_files('sycl', op, category2exampleop[category])
+        return generate_template(arc_src, example_arch_src, example_new_arch_src, 'SYCL')

--- a/prompts/sycl_new_model_add.py
+++ b/prompts/sycl_new_model_add.py
@@ -1,0 +1,75 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.cpp_extension import load_inline
+
+# Define the custom SYCL kernel for element-wise addition
+elementwise_add_source = """
+#include <sycl/sycl.hpp>
+#include <torch/extension.h>
+#include <iostream>
+
+void elementwise_add_sycl_kernel(torch::Tensor a, torch::Tensor b, torch::Tensor out, int size) {
+    auto a_data = a.data_ptr<float>();
+    auto b_data = b.data_ptr<float>();
+    auto out_data = out.data_ptr<float>();
+
+    // Create a SYCL queue
+    sycl::queue q(sycl::default_selector{});
+
+    // Allocate device memory for a, b, out
+    {
+        sycl::buffer<float> a_buffer(a_data, sycl::range<1>(size));
+        sycl::buffer<float> b_buffer(b_data, sycl::range<1>(size));
+        sycl::buffer<float> out_buffer(out_data, sycl::range<1>(size));
+
+        // Submit a command group to the queue
+        q.submit([&](sycl::handler& cgh) {
+            // Accessors for buffers
+            auto a_acc = a_buffer.get_access<sycl::access::mode::read>(cgh);
+            auto b_acc = b_buffer.get_access<sycl::access::mode::read>(cgh);
+            auto out_acc = out_buffer.get_access<sycl::access::mode::write>(cgh);
+
+            // Kernel for element-wise addition
+            cgh.parallel_for<class elementwise_add>(sycl::range<1>(size), [=](sycl::id<1> idx) {
+                out_acc[idx] = a_acc[idx] + b_acc[idx];
+            });
+        });
+    }
+
+    // Wait for the queue to finish the execution
+    q.wait();
+}
+
+torch::Tensor elementwise_add_sycl(torch::Tensor a, torch::Tensor b) {
+    auto size = a.numel();
+    auto out = torch::zeros_like(a);
+
+    // Call the SYCL function
+    elementwise_add_sycl_kernel(a, b, out, size);
+
+    return out;
+}
+"""
+
+elementwise_add_cpp_source = "torch::Tensor elementwise_add_sycl(torch::Tensor a, torch::Tensor b);"
+
+# Compile the inline SYCL code for element-wise addition
+elementwise_add = load_inline(
+    name="elementwise_add",
+    cpp_sources=elementwise_add_cpp_source,
+    sycl_sources=elementwise_add_source,
+    functions=["elementwise_add_sycl"],
+    verbose=True,
+    extra_cflags=[""],
+    extra_ldflags=[""],
+)
+
+
+class ModelNew(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.elementwise_add = elementwise_add
+
+    def forward(self, a, b):
+        return self.elementwise_add.elementwise_add_sycl(a, b)


### PR DESCRIPTION
Thanks for this nice work on providing an improved Kernel benchmark with more flexible code!

This PR aims to support SYCL as a backend, to write efficient kernels for Intel GPUs. It only required few changes to the code base, since with torch.xpu mimics the CUDA workflow.

With the code from this PR, I was able to successfully generate functional SYCL kernels and measure the runtime on Intel GPUs. 

Let me know if you have any questions!