### PR TITLE
Show full eval subprocess output and normalize correctness=False on failures

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -32,16 +32,10 @@ def eval_all(out_dir, language, categories, op_tested=dataset.keys()):
                     timeout=180
                 )
                 result_item = json.load(tf_output)
-                detailed_compiler_error = '\n'
                 if not result_item['compiled']:
-                    for line in captured_text.stdout.split('\n'):
-                        if '[ERROR]' in line or 'error:' in line:
-                            detailed_compiler_error += line
-                            detailed_compiler_error += '\n'
-                    for line in captured_text.stderr.split('\n'):
-                        if '[ERROR]' in line or 'error:' in line:
-                            detailed_compiler_error += line
-                            detailed_compiler_error += '\n'
+                    detailed_compiler_error = (
+                        '\n[STDOUT]\n' + captured_text.stdout + '\n[STDERR]\n' + captured_text.stderr
+                    )
                     result_item['compile_info'] += detailed_compiler_error
 
             except subprocess.CalledProcessError as e:
@@ -50,18 +44,25 @@ def eval_all(out_dir, language, categories, op_tested=dataset.keys()):
                     break
                 elif e.returncode == -11:
                     print("[FAIL] Segmentation fault" )
-                    seg_result = {'compiled': True, 'correctness': None, 'performance': None, 'correctness_info': 'Segmentation fault'} 
+                    seg_result = {'compiled': True, 'correctness': False, 'performance': None, 'correctness_info': 'Segmentation fault'} 
                     result[op] = seg_result
                     continue
                 else:
                     print("[FAIL] unknown error, please report or fix bug")
+                    print('[STDOUT]')
+                    print(e.stdout)
+                    print('[STDERR]')
                     print(e.stderr)
-                    unknown_result = {'compiled': True, 'correctness': None, 'performance': None, 'correctness_info': 'Unknown fault'} 
+                    unknown_result = {'compiled': True, 'correctness': False, 'performance': None, 'correctness_info': 'Unknown fault'} 
                     result[op] = unknown_result
                     continue
             except subprocess.TimeoutExpired as e:
                 print("[FAIL] run timeout")
-                time_result = {'compiled': True, 'correctness': None, 'performance': None, 'correctness_info': 'Timeout fault'} 
+                print('[STDOUT]')
+                print(e.stdout)
+                print('[STDERR]')
+                print(e.stderr)
+                time_result = {'compiled': True, 'correctness': False, 'performance': None, 'correctness_info': 'Timeout fault'} 
                 result[op] = time_result
                 continue
             result[op] = result_item

--- a/utils/evaluation_utils.py
+++ b/utils/evaluation_utils.py
@@ -43,7 +43,7 @@ def eval_single(response_txt:str, op, language):
     
     hardware = backend.get_hardware_name()
 
-    result = {'compiled': False, 'correctness': None, 'performance': None, 'hardware':hardware}
+    result = {'compiled': False, 'correctness': False, 'performance': None, 'hardware':hardware}
     generated_code = extract_first_code(response_txt, ['python', 'cpp'])
     if generated_code is None:
         generated_code = response_txt


### PR DESCRIPTION
### Motivation

- Make evaluation failures more actionable by exposing the full subprocess `stdout`/`stderr` instead of silently filtering lines, and standardize failure semantics so `correctness` is a boolean (`False`) for failure cases instead of `None`.

### Description

- In `evaluation.py` include the full `captured_text.stdout` and `captured_text.stderr` in `compile_info` when a compiled result reports failure, replacing the previous line-filtering behavior.
- In `evaluation.py` print both `stdout` and `stderr` for unknown `CalledProcessError` and for `TimeoutExpired` exceptions to improve debugging visibility.
- In `evaluation.py` normalize fallback result objects for segmentation faults, unknown faults, and timeouts to set `correctness: False` instead of `None`.
- In `utils/evaluation_utils.py` change the default per-op `result['correctness']` from `None` to `False` so early-return or compile-failure paths consistently emit `correctness: false` in output JSON.

### Testing

- Ran static bytecode check with `python -m py_compile evaluation.py utils/evaluation_utils.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf98876c748329bf0263f5c5c661a5)