### PR TITLE
Improve error reporting and failure semantics in evaluation and Ascend compile pipeline

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -32,16 +32,10 @@ def eval_all(out_dir, language, categories, op_tested=dataset.keys()):
                     timeout=180
                 )
                 result_item = json.load(tf_output)
-                detailed_compiler_error = '\n'
                 if not result_item['compiled']:
-                    for line in captured_text.stdout.split('\n'):
-                        if '[ERROR]' in line or 'error:' in line:
-                            detailed_compiler_error += line
-                            detailed_compiler_error += '\n'
-                    for line in captured_text.stderr.split('\n'):
-                        if '[ERROR]' in line or 'error:' in line:
-                            detailed_compiler_error += line
-                            detailed_compiler_error += '\n'
+                    detailed_compiler_error = (
+                        '\n[STDOUT]\n' + captured_text.stdout + '\n[STDERR]\n' + captured_text.stderr
+                    )
                     result_item['compile_info'] += detailed_compiler_error
 
             except subprocess.CalledProcessError as e:
@@ -50,18 +44,25 @@ def eval_all(out_dir, language, categories, op_tested=dataset.keys()):
                     break
                 elif e.returncode == -11:
                     print("[FAIL] Segmentation fault" )
-                    seg_result = {'compiled': True, 'correctness': None, 'performance': None, 'correctness_info': 'Segmentation fault'} 
+                    seg_result = {'compiled': True, 'correctness': False, 'performance': None, 'correctness_info': 'Segmentation fault'} 
                     result[op] = seg_result
                     continue
                 else:
                     print("[FAIL] unknown error, please report or fix bug")
+                    print('[STDOUT]')
+                    print(e.stdout)
+                    print('[STDERR]')
                     print(e.stderr)
-                    unknown_result = {'compiled': True, 'correctness': None, 'performance': None, 'correctness_info': 'Unknown fault'} 
+                    unknown_result = {'compiled': True, 'correctness': False, 'performance': None, 'correctness_info': 'Unknown fault'} 
                     result[op] = unknown_result
                     continue
             except subprocess.TimeoutExpired as e:
                 print("[FAIL] run timeout")
-                time_result = {'compiled': True, 'correctness': None, 'performance': None, 'correctness_info': 'Timeout fault'} 
+                print('[STDOUT]')
+                print(e.stdout)
+                print('[STDERR]')
+                print(e.stderr)
+                time_result = {'compiled': True, 'correctness': False, 'performance': None, 'correctness_info': 'Timeout fault'} 
                 result[op] = time_result
                 continue
             result[op] = result_item

--- a/utils/ascend_compile_pipeline.py
+++ b/utils/ascend_compile_pipeline.py
@@ -5,6 +5,10 @@ from config import op_engineer_dir, deploy_path, ascendc_device, project_root_pa
 from utils.utils import underscore_to_pascalcase
 
 
+def _format_subprocess_output(stdout, stderr):
+    return f"[STDOUT]\n{stdout or ''}\n[STDERR]\n{stderr or ''}"
+
+
 def _inject_kernel_include_paths(target_directory, include_paths):
     if not include_paths:
         return
@@ -62,10 +66,9 @@ def ascend_compile(generated_code, op, context, extra_kernel_include_paths=None)
         print("[INFO] Create operator project succeeded")
     except subprocess.CalledProcessError as e:
         print("[INFO] Create operator project failed!")
-        # print("Exit Code:", e.returncode)
-        print("Error Output:\n", e.stdout)
-        print("Error Output:\n", e.stderr)
-        feedback = f'Exit Code: {e.returncode}\nError Output:\n{e.stdout}'
+        error_output = _format_subprocess_output(e.stdout, e.stderr)
+        print(error_output)
+        feedback = f'Exit Code: {e.returncode}\nError Output:\n{error_output}'
         raise Exception(feedback) 
 
     # write code to specific location
@@ -92,17 +95,8 @@ def ascend_compile(generated_code, op, context, extra_kernel_include_paths=None)
         print("[INFO] Build succeeded")
     except subprocess.CalledProcessError as e:
         print("[INFO] Build failed!")
-        error_output = ''
-        for line in e.stdout.split('\n'):
-            if '[ERROR]' in line or 'error:' in line:
-                print(line)
-                error_output += line
-                error_output += '\n'
-        for line in e.stderr.split('\n'):
-            if '[ERROR]' in line or 'error:' in line:
-                print(line)
-                error_output += line
-                error_output += '\n'
+        error_output = _format_subprocess_output(e.stdout, e.stderr)
+        print(error_output)
         feedback = f'Exit Code: {e.returncode}\nError Output:\n{error_output}'
         raise Exception(feedback)
 
@@ -116,7 +110,9 @@ def ascend_compile(generated_code, op, context, extra_kernel_include_paths=None)
         print("[INFO] Deploy succeeded")
     except subprocess.CalledProcessError as e:
         print("[INFO] Deploy failed!")
-        feedback = f'Exit Code: {e.returncode}\nError Output:\n{e.stdout}'
+        error_output = _format_subprocess_output(e.stdout, e.stderr)
+        print(error_output)
+        feedback = f'Exit Code: {e.returncode}\nError Output:\n{error_output}'
         raise Exception(feedback)
 
 
@@ -129,7 +125,9 @@ def ascend_compile(generated_code, op, context, extra_kernel_include_paths=None)
     except subprocess.CalledProcessError as e:
         # Print error if build.sh fails
         print("[INFO] Pybind failed!")
-        feedback = f'Exit Code: {e.returncode}\nError Output:\n{e.stdout}'
+        error_output = _format_subprocess_output(e.stdout, e.stderr)
+        print(error_output)
+        feedback = f'Exit Code: {e.returncode}\nError Output:\n{error_output}'
         raise Exception(feedback)
 
     # Update ASCEND_CUSTOM_OPP_PATH

--- a/utils/evaluation_utils.py
+++ b/utils/evaluation_utils.py
@@ -43,7 +43,7 @@ def eval_single(response_txt:str, op, language):
     
     hardware = backend.get_hardware_name()
 
-    result = {'compiled': False, 'correctness': None, 'performance': None, 'hardware':hardware}
+    result = {'compiled': False, 'correctness': False, 'performance': None, 'hardware':hardware}
     generated_code = extract_first_code(response_txt, ['python', 'cpp'])
     if generated_code is None:
         generated_code = response_txt


### PR DESCRIPTION
### Motivation
- Make failures clearer by preserving full subprocess output (stdout/stderr) for diagnostics when compilation, build, deploy, or runtime steps fail. 
- Ensure downstream evaluation consistently marks failed runs as incorrect instead of leaving correctness as `None` for error conditions. 
- Centralize formatting of subprocess output to avoid repeated ad-hoc parsing and improve readability of logs.

### Description
- Updated `evaluation.py` to attach full captured stdout/stderr to `compile_info` when compile fails and to print stdout/stderr on `CalledProcessError` and `TimeoutExpired` paths. 
- Changed error-case result semantics in `evaluation.py` so `correctness` is set to `False` for segmentation faults, unknown errors, and timeouts instead of `None`. 
- Added a helper `_format_subprocess_output` to `utils/ascend_compile_pipeline.py` and replaced previous ad-hoc filtering with consistent formatting of both stdout and stderr in `msopgen`, `build.sh`, deploy, and pybind subprocess error handlers. 
- Replaced selective error-line extraction with full stdout/stderr capture when reporting feedback from subprocess failures. 
- Initialized `result['correctness']` to `False` by default in `utils/evaluation_utils.py` so unambiguous correctness is reported for failed/early-exit paths.

### Testing
- Ran the repository unit test suite with `pytest`, which executed backend compile and error-path unit tests, and all tests passed. 
- Performed a small integration smoke test by running the evaluation runner on a sample operator (invoking `eval_single`/`eval_all`), and observed that compile/build failures now include both `[STDOUT]` and `[STDERR]` blocks and that error cases set `correctness` to `False` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf98876c748329bf0263f5c5c661a5)