### PR TITLE
Bump torch to 2.7.1, update NPU install guidance, and relax numpy pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ conda activate multi-kernel-bench
 pip install -r requirements.txt
 
 # For NPU users:
-pip install torch-npu==2.1.0.post12
+pip install torch-npu==2.7.1
 
 # For Intel GPU (torch xpu) users:
 pip install torch==2.7.0 --index-url https://download.pytorch.org/whl/xpu

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 numpy
 openai
 packaging
-torch==2.1.0
-numpy==1.26.4
+torch==2.7.1
 decorator
 scipy
 psutil


### PR DESCRIPTION
### Motivation
- Align install instructions and dependency pins with a newer `torch` release and remove an unnecessary strict `numpy` constraint.

### Description
- Updated `README.md` to recommend `pip install torch-npu==2.7.1` for NPU users and refreshed the news section, and modified `requirements.txt` to pin `torch==2.7.1`, remove the redundant `numpy==1.26.4` constraint, and normalize the file newline.

### Testing
- No automated tests were run for this dependency and docs update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2516896888329a352a7bca1f60f72)