### PR TITLE
Increase Add operator tiling parameters and scale CUDA test inputs

### DIFF
--- a/prompts/ascendc_new_model_add.py
+++ b/prompts/ascendc_new_model_add.py
@@ -60,8 +60,8 @@ host_operator_src="""
 
 
 namespace optiling {
-const uint32_t BLOCK_DIM = 8;
-const uint32_t TILE_NUM = 8;
+const uint32_t BLOCK_DIM = 32;
+const uint32_t TILE_NUM = 4096;
 static ge::graphStatus TilingFunc(gert::TilingContext* context)
 {
 

--- a/prompts/cuda_model_add.py
+++ b/prompts/cuda_model_add.py
@@ -13,8 +13,8 @@ class Model(nn.Module):
 
 def get_inputs():
     # randomly generate input tensors based on the model architecture
-    a = torch.randn(2, 2048)
-    b = torch.randn(2, 2048)
+    a = torch.randn(4096, 393216)
+    b = torch.randn(4096, 393216)
     return [a, b]
 
 


### PR DESCRIPTION
### Motivation
- Increase tiling/block parameters to exercise larger workloads and improve parallelism for the custom Add operator.
- Scale the CUDA test input tensors so the tiling logic computes a realistic and larger `totalLength` for testing.

### Description
- Changed `BLOCK_DIM` from `8` to `32` and `TILE_NUM` from `8` to `4096` in `prompts/ascendc_new_model_add.py`.
- Increased the generated test input tensor shapes in `prompts/cuda_model_add.py` from `(2, 2048)` to `(4096, 393216)` for both `a` and `b` in `get_inputs()`.
- Preserved existing tiling data serialization and shape inference behavior; `totalLength` is still derived from the input shape and written to the tiling buffer.

### Testing
- Ran shape inference and tiling registration unit tests that exercise the `AddCustom` operator and they passed.
- Executed the `get_inputs()` generator to validate the new tensor shapes and allocation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c398d2feb883298d141d736b730cbb)